### PR TITLE
Add initial impl of array_chunks_and_windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5462,6 +5462,7 @@ Released 2018-09-13
 [`arbitrary_source_item_ordering`]: https://rust-lang.github.io/rust-clippy/master/index.html#arbitrary_source_item_ordering
 [`arc_with_non_send_sync`]: https://rust-lang.github.io/rust-clippy/master/index.html#arc_with_non_send_sync
 [`arithmetic_side_effects`]: https://rust-lang.github.io/rust-clippy/master/index.html#arithmetic_side_effects
+[`array_chunks_and_windows`]: https://rust-lang.github.io/rust-clippy/master/index.html#array_chunks_and_windows
 [`as_conversions`]: https://rust-lang.github.io/rust-clippy/master/index.html#as_conversions
 [`as_pointer_underscore`]: https://rust-lang.github.io/rust-clippy/master/index.html#as_pointer_underscore
 [`as_ptr_cast_mut`]: https://rust-lang.github.io/rust-clippy/master/index.html#as_ptr_cast_mut

--- a/clippy_lints/src/array_chunks_and_windows.rs
+++ b/clippy_lints/src/array_chunks_and_windows.rs
@@ -1,0 +1,59 @@
+use clippy_utils::consts::Constant;
+use clippy_utils::diagnostics::span_lint;
+use clippy_utils::source::SpanRangeExt;
+use rustc_hir::*;
+use rustc_lint::{LateContext, LateLintPass};
+use rustc_session::declare_lint_pass;
+
+declare_clippy_lint! {
+    /// ### What it does
+    /// The lint suggests using `array_windows`  and `array_chunks` instead of `windows` and `chunks`
+    /// when a constant value is specified. This allows for a more performant execution.
+    /// ### Why is this bad?
+    /// It adds unnecessary heap allocation.
+    /// ### Example
+    /// ```no_run
+    /// for window in slice.windows(2) {
+    ///     println!("{} {}", w[0], w[1]);
+    /// }
+    /// ```
+    /// Use instead:
+    /// ```no_run
+    /// for [a, b] in slice.array_windows() {
+    ///     println!("{} {}", a, b);
+    /// }
+    /// ```
+    #[clippy::version = "1.87.0"]
+    pub ARRAY_CHUNKS_AND_WINDOWS,
+    nursery,
+    "default lint description"
+}
+
+declare_lint_pass!(ArrayChunksAndWindows => [ARRAY_CHUNKS_AND_WINDOWS]);
+
+impl LateLintPass<'_> for ArrayChunksAndWindows {
+    fn check_expr(&mut self, cx: &LateContext<'_>, expr: &Expr<'_>) {
+        if let ExprKind::MethodCall(name, _, args, span) = expr.kind
+            && (name.ident.as_str() == "windows" || name.ident.as_str() == "chunks")
+            && let [expr] = args
+        {
+            if let ExprKind::Lit(l) = clippy_utils::expr_or_init(cx, expr).kind {
+                let arg = clippy_utils::consts::lit_to_mir_constant(&l.node, None);
+                if let Constant::Int(n) = arg
+                    && n <= 26
+                {
+                    span_lint(
+                        cx,
+                        ARRAY_CHUNKS_AND_WINDOWS,
+                        span,
+                        format!(
+                            "use .array_{name}() instead of .{name}({expr})",
+                            name = name.ident.as_str(),
+                            expr = expr.span.get_source_text(cx).unwrap()
+                        ),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -38,6 +38,7 @@ pub static LINTS: &[&crate::LintInfo] = &[
     crate::approx_const::APPROX_CONSTANT_INFO,
     crate::arbitrary_source_item_ordering::ARBITRARY_SOURCE_ITEM_ORDERING_INFO,
     crate::arc_with_non_send_sync::ARC_WITH_NON_SEND_SYNC_INFO,
+    crate::array_chunks_and_windows::ARRAY_CHUNKS_AND_WINDOWS_INFO,
     crate::as_conversions::AS_CONVERSIONS_INFO,
     crate::asm_syntax::INLINE_ASM_X86_ATT_SYNTAX_INFO,
     crate::asm_syntax::INLINE_ASM_X86_INTEL_SYNTAX_INFO,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -78,6 +78,7 @@ mod almost_complete_range;
 mod approx_const;
 mod arbitrary_source_item_ordering;
 mod arc_with_non_send_sync;
+mod array_chunks_and_windows;
 mod as_conversions;
 mod asm_syntax;
 mod assertions_on_constants;
@@ -984,5 +985,6 @@ pub fn register_lints(store: &mut rustc_lint::LintStore, conf: &'static Conf) {
     store.register_late_pass(move |_| Box::new(non_std_lazy_statics::NonStdLazyStatic::new(conf)));
     store.register_late_pass(|_| Box::new(manual_option_as_slice::ManualOptionAsSlice::new(conf)));
     store.register_late_pass(|_| Box::new(single_option_map::SingleOptionMap));
+    store.register_late_pass(|_| Box::new(array_chunks_and_windows::ArrayChunksAndWindows));
     // add lints here, do not remove this comment, it's used in `new_lint`
 }

--- a/tests/ui/array_chunks_and_windows.rs
+++ b/tests/ui/array_chunks_and_windows.rs
@@ -1,0 +1,45 @@
+#![warn(clippy::array_chunks_and_windows)]
+
+fn use_slice_windows_literal() {
+    // test code goes here
+    let slice = [1, 2, 3];
+    for window in slice.windows(2) {
+        println!("{} {}", window[0], window[1]);
+    }
+}
+
+fn use_slice_windows_variable() {
+    // test code goes here
+    let slice = [1, 2, 3];
+    let i = 2;
+    for window in slice.windows(i) {
+        println!("{} {}", window[0], window[1]);
+    }
+}
+
+fn use_slice_chunks_literal() {
+    // test code goes here
+    let slice = [1, 2, 3];
+    for chunk in slice.chunks(2) {
+        println!("{} {}", chunk[0], chunk[1]);
+    }
+}
+
+fn use_slice_chunks_variable() {
+    // test code goes here
+    let slice = [1, 2, 3];
+    let i = 2;
+    for chunk in slice.chunks(i) {
+        println!("{} {}", chunk[0], chunk[1]);
+    }
+}
+
+fn use_long_slice_windows_literal() {
+    // test code goes here
+    let slice = [1, 2, 3];
+    for window in slice.windows(27) {
+        println!("{} {}", window[0], window[1]);
+    }
+}
+
+fn main() {}

--- a/tests/ui/array_chunks_and_windows.stderr
+++ b/tests/ui/array_chunks_and_windows.stderr
@@ -1,0 +1,29 @@
+error: use .array_windows() instead of .windows(2)
+  --> tests/ui/array_chunks_and_windows.rs:6:25
+   |
+LL |     for window in slice.windows(2) {
+   |                         ^^^^^^^^^^
+   |
+   = note: `-D clippy::array-chunks-and-windows` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::array_chunks_and_windows)]`
+
+error: use .array_windows() instead of .windows(i)
+  --> tests/ui/array_chunks_and_windows.rs:15:25
+   |
+LL |     for window in slice.windows(i) {
+   |                         ^^^^^^^^^^
+
+error: use .array_chunks() instead of .chunks(2)
+  --> tests/ui/array_chunks_and_windows.rs:23:24
+   |
+LL |     for chunk in slice.chunks(2) {
+   |                        ^^^^^^^^^
+
+error: use .array_chunks() instead of .chunks(i)
+  --> tests/ui/array_chunks_and_windows.rs:32:24
+   |
+LL |     for chunk in slice.chunks(i) {
+   |                        ^^^^^^^^^
+
+error: aborting due to 4 previous errors
+


### PR DESCRIPTION
.array_chunks() and .array_windows() are still nightly, so it goes to the nursery lints.

See: https://github.com/rust-lang/rust-clippy/issues/6580

Thank you for making Clippy better!

We're collecting our changelog from pull request descriptions.
If your PR only includes internal changes, you can just write
`changelog: none`. Otherwise, please write a short comment
explaining your change.

It's also helpful for us that the lint name is put within backticks (`` ` ` ``),
and then encapsulated by square brackets (`[]`), for example:
```
changelog: [`lint_name`]: your change
```

If your PR fixes an issue, you can add `fixes #issue_number` into this
PR description. This way the issue will be automatically closed when
your PR is merged.

If you added a new lint, here's a checklist for things that will be
checked during review or continuous integration.

- \[ ] Followed [lint naming conventions][lint_naming]
- \[ ] Added passing UI tests (including committed `.stderr` file)
- \[ ] `cargo test` passes locally
- \[ ] Executed `cargo dev update_lints`
- \[ ] Added lint documentation
- \[ ] Run `cargo dev fmt`

[lint_naming]: https://rust-lang.github.io/rfcs/0344-conventions-galore.html#lints

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.

Delete this line and everything above before opening your PR.

---

*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog:
